### PR TITLE
redefined subplots to prevent a matplotlib warning

### DIFF
--- a/plotting/visualise_viability.py
+++ b/plotting/visualise_viability.py
@@ -22,6 +22,55 @@ def visualise(data, initial_conditions = [], include_end_state = False,  state_c
 	end_state[Q_V != 1] = np.nan
 	change_state   = end_state - initial_state
 
+	if include_end_state:	
+		fig, (ax2, ax) = plt.subplots(nrows=2)
+		im2 = ax2.imshow(end_state, origin = 'lower', extent = [a_min, a_max, s_min, s_max], cmap = state_colormap)
+		fig.colorbar(im2, ax=ax2)
+		ax2.set_ylabel('State')
+		ax2.set_title('End state')
+		ax2.set_xticks([])
+
+	else: 	
+		fig, ax = plt.subplots()
+	min_change = np.min(change_state[Q_V == 1])
+	max_change = np.max(change_state[Q_V == 1])
+	change     = max(abs(min_change), abs(max_change))
+	im = ax.imshow(change_state, origin = 'lower', extent = [a_min, a_max, s_min, s_max], vmin = - change, vmax = change, cmap = change_colormap)
+	fig.colorbar(im, ax=ax)
+	ax.set_xlabel('Angle of attack (rad)')
+	ax.set_ylabel('State')
+	ax.set_title('Change in state')	
+	
+	if len(initial_conditions) > 0:
+		## To determine the lower bound on state
+		s_lower = np.cos(a_grid)/(initial_conditions[1]+initial_conditions[2]**2/(2*9.81)) # height at touchdown / (height + speed^2/2g)
+		ax.plot(a_grid, s_lower, color = 'k')
+		ax.fill_between(a_grid, s_lower, color = 'grey')	
+		if include_end_state:		
+			ax2.plot(a_grid, s_lower, color = 'k')
+			ax2.fill_between(a_grid, s_lower, color = 'grey')	
+		
+	plt.show(block=False)
+
+def visualise_old(data, initial_conditions = [], include_end_state = False,  state_colormap = state_colormap, change_colormap = change_colormap):
+
+	s_grid	= data['s_grid']	# shape 50
+	a_grid	= data['a_grid']	# shape 50 (in radian? angles?)
+	Q_map	= data['Q_map']		# shape 50 x 50
+	Q_V		= data['Q_V']		# shape 50 x 50: binary non-failure
+
+	s_min = s_grid[0]
+	s_max = s_grid[-1]
+	a_min = a_grid[0]
+	a_max = a_grid[-1]
+
+	initial_state  = np.repeat(np.array([s_grid]), len(a_grid), axis = 0).T
+	end_state      = np.zeros((len(s_grid), len(a_grid)))
+	end_state[Q_V == 1] = Q_map[Q_V == 1]
+	end_state[Q_V != 1] = np.nan
+	change_state   = end_state - initial_state
+
+	
 	plt.figure()
 	
 	if include_end_state:	


### PR DESCRIPTION
It's not so much an error as a warning. There's a different way to define subplots which prevents that warning from coming up: I rewrote the function visualise in that way. For comparison, I left the old version of the function (now called visualise_old), if you're curious about the changes; you can also remove this old function if you want.